### PR TITLE
Fix warning since WC >= 2.5.3

### DIFF
--- a/includes/integration.php
+++ b/includes/integration.php
@@ -80,7 +80,7 @@ class WeDevs_WC_Tracking_Integration extends WC_Integration {
      * @param string $key
      * @return string
      */
-    function validate_textarea_field( $key ) {
+    function validate_textarea_field( $key, $value ) {
         $text = trim( stripslashes( $_POST[$this->plugin_id . $this->id . '_' . $key] ) );
 
         return $text;


### PR DESCRIPTION
Fixes warning `Warning: Declaration of WeDevs_WC_Tracking_Integration::validate_textarea_field($key) should be compatible with WC_Settings_API::validate_textarea_field($key, $value) in ...` after WooCommerce 2.5.3